### PR TITLE
Clean up compiler/library flags

### DIFF
--- a/.github/workflows/submodule-sync.yaml
+++ b/.github/workflows/submodule-sync.yaml
@@ -1,0 +1,51 @@
+name: Sync check
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+
+  sync-check-job:
+    name: Sync check
+    runs-on: ubuntu-latest
+    env:
+      AUTOMATED_TESTING: 1
+      NONINTERACTIVE_TESTING: 1
+      RELEASE_TESTING: 1
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Install Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: "5.36"
+          install-modules: >
+            IPC::Run
+            Path::Tiny
+          install-modules-with: cpanm
+          install-modules-args: --skip-satisfied
+      - name: Run nc-update
+        run: |
+          perl nc-update.pl --force
+      - name: Verify build dir is in sync with submodule
+        run: |
+          git status --untracked-files=no --porcelain=v1 |
+            grep -E '\.(ac|am|c|h)$|neo4j-client\.h\.in|autogen\.sh' |
+            tee git-status
+          git diff -- '*.ac' '*.am' '*.c' '*.h' neo4j-client.h.in autogen.sh
+          test ! -s git-status
+
+# Untracked files are currently skipped here because nc-update.pl creates
+# some files in build that are neither committed nor are they in .gitignore
+# and I haven't looked into which of these two would be correct.
+
+# If this workflow fails, you probably forgot to commit the changes made by nc-update.pl.
+
+# To skip this workflow in case of intentional differences between submodule and build dir:
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
           END
           fi
           cpanm . --notest --installdeps --with-configure --skip-satisfied
+          cpanm FFI::Platypus Inline::C --notest --skip-satisfied
       - name: Build
         run: |
           perl Makefile.PL
@@ -67,13 +68,15 @@ jobs:
             File::Which
             Path::Tiny~0.014
 
-            Test2::V0
+            FFI::Platypus
+            Inline::C
 
           install-modules-with: cpanm
           install-modules-args: --skip-satisfied
       - name: Install dependencies
         run: |
           cpanm . --notest --installdeps --with-configure --skip-satisfied
+          cpanm FFI::Platypus Inline::C --notest --skip-satisfied
       - name: Build
         run: |
           perl Makefile.PL

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,83 @@
+name: Alien test
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+
+# The environments created by Docker and Setup action differ to the point where
+# we've seen linking fail in only one of them, so it's useful to test both.
+
+  docker-job:
+    name: Docker container
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:5.20
+    env:
+      AUTOMATED_TESTING: 1
+      NONINTERACTIVE_TESTING: 1
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v5
+      - name: Install dependencies
+        run: |
+          if ! [ -e cpanfile ]
+          then
+            cpanm --notest --skip-satisfied <<END
+
+            Alien::Build::MM~1.19
+            Alien::OpenSSL~0.09
+            Capture::Tiny
+            ExtUtils::MakeMaker~6.64
+            File::Which
+            Path::Tiny~0.014
+
+          END
+          fi
+          cpanm . --notest --installdeps --with-configure --skip-satisfied
+      - name: Build
+        run: |
+          perl Makefile.PL
+          make
+      - name: Test
+        run: |
+          make test
+
+  shogo-job:
+    name: Setup action
+    runs-on: ubuntu-latest
+    env:
+      AUTOMATED_TESTING: 1
+      NONINTERACTIVE_TESTING: 1
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v5
+      - name: Install Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: "5.40"
+          install-modules: >
+
+            Alien::Build::MM~1.19
+            Alien::OpenSSL~0.09
+            Capture::Tiny
+            ExtUtils::MakeMaker~6.64
+            File::Which
+            Path::Tiny~0.014
+
+            Test2::V0
+
+          install-modules-with: cpanm
+          install-modules-args: --skip-satisfied
+      - name: Install dependencies
+        run: |
+          cpanm . --notest --installdeps --with-configure --skip-satisfied
+      - name: Build
+        run: |
+          perl Makefile.PL
+          make
+      - name: Test
+        run: |
+          make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,8 @@ jobs:
 
             FFI::Platypus
             Inline::C
+            Test::CPAN::Changes
+            Test::Pod
 
           install-modules-with: cpanm
           install-modules-args: --skip-satisfied

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.bak
+*.old
+*~
+
+/Makefile
+/MYMETA.*
+
+/_alien/
+/blib/
+/pm_to_blib

--- a/BUILD.md
+++ b/BUILD.md
@@ -92,10 +92,12 @@ diff MANIFEST.bak MANIFEST
 rm MANIFEST.bak
 git checkout -- MANIFEST
 
-# Create the dist tarball
+# Create and test the dist tarball
 # (running `make` or `make test` isn't necessary before `make dist`)
 make dist
-
-# Test the dist tarball
 cpanm --test-only Neo4j-Client-*.tar.gz
+
+# See full test output
+cpanm --installdeps --with-develop --with-recommends Neo4j-Client-*.tar.gz
+make && prove -b
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,3 +8,94 @@ To update to a new version of [libneo4j-omni](http://github.com/majensen/libneo4
  * The file [NC-MANIFEST](/NC-MANIFEST) lists the files required from libneo4j-omni to build the appropriate library for Neo4j::Client.
  * `nc-update.pl` subsets these files into the directory [build](/build) and performs some required rewriting.
 * Build as usual with `perl Makefile.PL` and `make`.
+
+
+## First step: Prepare the library
+
+Some of the following commands may be helpful for handling the libneo4j-omni
+submodule:
+
+```sh
+# Populate an empty submodule dir after cloning Neo4j::Client
+git submodule init
+git submodule update
+
+# Update to the latest commit on the libneo4j-omni main branch:
+git submodule update --rebase --remote
+
+# Look at a specific GitHub PR, for trial releases etc.:
+git submodule foreach git checkout origin/pr123
+git submodule update origin/pr123
+
+# Temporary test build with a local libneo4j-omni branch:
+rm -Rf libneo4j-omni
+git clone -b BRANCH --depth 1 file://...
+```
+
+The submodule directory won't be included in the Perl module tarball.
+The module will compile the library from the `build` directory,
+which needs to be updated with the `nc-update` staging script.
+The Perl version of that script is the newer one;
+the shell script with the same name is no longer used.
+
+The staging script requires Autoconf, Automake, Libtool, and m4 to be
+installed on the system. The script currently doesn't use the versions
+of these tools that are bundled with Neo4j::Client.
+
+```sh
+# Install nc-update prerequisites
+brew    install automake libtool  # Darwin
+apt-get install automake libtool  # Debian
+cpanm IPC::Run Path::Tiny
+
+perl nc-update.pl --force
+```
+
+
+## Second step: Prepare the Perl module
+
+For releasing an updated version to CPAN:
+
+- Bump version number in [lib/Neo4j/Client.pm](lib/Neo4j/Client.pm).
+- Update [Changes](Changes).  
+    (Given that Neo4j::Client bundles libneo4j-omni, significant changes
+    in libneo4j-omni since the last Neo4j::Client release should probably
+    be described here, *at least* briefly in general terms.)
+- Update prereqs and other metadata in [Makefile.PL](Makefile.PL) as appropriate.
+- Update [Client.md](lib/Neo4j/Client.md)/[README.md](README.md) with any POD changes:
+    ```sh
+    sed -e '/local_module_re/s/Neo4j::Bolt/Neo4j::Client/' ../perlbolt/pod2md.PL |
+    perl - lib/Neo4j/Client.pm && cp lib/Neo4j/Client.md README.md && echo ok
+    ```
+
+For a CPAN trial release, these markers should additionally be added:
+
+- [Client.pm](lib/Neo4j/Client.pm), after the version number line: `# TRIAL`
+- [Changes](Changes), after the version number: `(TRIAL RELEASE)`
+- [Makefile.PL](Makefile.PL), in the meta hash: `release_status => 'testing',`
+- Tarball name, after the version number: `-TRIAL`
+
+
+## Third step: Build the distribution tarball
+
+```sh
+# Install prereqs
+cpanm --installdeps Neo4j::Client
+
+# The manifest should be verified manually, to make sure no new files
+# are accidentally omitted.
+perl Makefile.PL && make realclean
+perl Makefile.PL && make manifest
+diff MANIFEST.bak MANIFEST
+
+# Revert to old manifest
+rm MANIFEST.bak
+git checkout -- MANIFEST
+
+# Create the dist tarball
+# (running `make` or `make test` isn't necessary before `make dist`)
+make dist
+
+# Test the dist tarball
+cpanm --test-only Neo4j-Client-*.tar.gz
+```

--- a/Changes
+++ b/Changes
@@ -1,5 +1,15 @@
 Revision history for Perl module Neo4j::Client
 
+0.56  2025-11-06
+    - Make compiler and linker flags work more reliably, in particular libs():
+        - Gives the path to the static libraries instead of the dynamic ones
+        - Fixed the order of -l flags: first libneo4j-omni, then OpenSSL
+    - Add support for "use Inline with" syntax
+    - Add libneo4j-omni package version to Alien metadata
+    - Rewrite synopsis to include examples of using this module through
+      Alien::Base::Wrapper, Inline::C, FFI:Platypus
+    - Known bug: Since 0.54, this module requires OpenSSL 1.1.0 or later
+
 0.55  2025-10-19
     - Update libneo4j-omni to version 5.0.7, comprising the following changes:
         - Change the preferred Bolt v4 version from 4.0 to 4.4

--- a/MANIFEST
+++ b/MANIFEST
@@ -109,6 +109,7 @@ MANIFEST			This list of files
 README
 README.md
 t/001_alien.t
+t/020_inline.t
 t/098_pod.t
 t/099_cpan_changes.t
 tools/ac/alienfile

--- a/MANIFEST
+++ b/MANIFEST
@@ -110,6 +110,8 @@ README
 README.md
 t/001_alien.t
 t/020_inline.t
+t/021_ffi.t
+t/030_sslversion.t
 t/098_pod.t
 t/099_cpan_changes.t
 tools/ac/alienfile

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,18 +1,34 @@
+# Backup files
 \.bak$
 \.old$
 ~$
 ^#.*#$
 ^\.#
+
+# SCM and OS files
+^\.git
+\.DS_Store$
+
+# MakeMaker files
 ^MANIFEST\.
+^Makefile$
 ^MakeMaker-\d
 ^MYMETA
-.git/.*
-.gitmodules
+
+# Build files
 _alien/.*
-libneo4j-omni/.*
-\/blib\/
+^blib/
+^pm_to_blib$
 try/.*
 Neo4j-Client.*tar.gz
+
+# Project files
+^libneo4j-omni/
+^BUILD\.md$
+^NC-MANIFEST$
+^nc-update\.pl$
 nc-update\.sh
+
+# Private files
 mdify\.pl
 \bnotes\b

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,6 +43,9 @@ WriteMakefile($mm->mm_args(
           'FFI::Platypus' => 0,
           'Inline::C' => 0,
         },
+        requires => {
+          'IPC::Run' => 0,  # nc-update
+        },
       },
     },
     resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,6 +41,7 @@ WriteMakefile($mm->mm_args(
       develop => {
         recommends => {
           'FFI::Platypus' => 0,
+          'Inline::C' => 0,
         },
       },
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,6 +42,8 @@ WriteMakefile($mm->mm_args(
         recommends => {
           'FFI::Platypus' => 0,
           'Inline::C' => 0,
+          'Test::CPAN::Changes' => 0,
+          'Test::Pod' => 0,
         },
         requires => {
           'IPC::Run' => 0,  # nc-update

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,13 @@ WriteMakefile($mm->mm_args(
   },
   META_MERGE => {
     'meta-spec' => { version => 2 },
+    prereqs => {
+      develop => {
+        recommends => {
+          'FFI::Platypus' => 0,
+        },
+      },
+    },
     resources => {
       bugtracker => {
 	web => 'https://github.com/majensen/neoclient/issues',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,6 +61,9 @@ WriteMakefile($mm->mm_args(
   dist => {
     TAR => 'ptar',  # avoid extended headers in tarball
   },
+  realclean => {
+    FILES => 'MANIFEST.bak build/configure~',
+  },
  ));
 
 sub MY::postamble {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
 Supplying compiler flags manually (not recommended):
 
     # for ExtUtils::MakeMaker
+    use Config;
     WriteMakefile(
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
@@ -67,6 +68,14 @@ Thanks to the miracle of [Alien::Build](https://metacpan.org/pod/Alien::Build), 
 contain OpenSSL support. This is already taken into account by the
 methods in [Alien::Base](https://metacpan.org/pod/Alien::Base), which are inherited by this module.
 You shouldn't need to add any extra compiler flags for OpenSSL.
+
+# BUGS
+
+The minimum supported version of OpenSSL is currently 1.1.0.
+([GH #7](https://github.com/majensen/neoclient/issues/7))
+
+The C compiler must support the `-Wpedantic` and `-Wvla` options.
+([GH #8](https://github.com/majensen/neoclient/issues/8))
 
 # SEE ALSO
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     # The wrapper will supply all compiler flags needed for
     # your Perl module to use libneo4j-omni automatically.
 
+With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
+
+    use FFI::CheckLib 0.25;
+    use FFI::Platypus;
+
+    my $ffi = FFI::Platypus->new;
+    $ffi->lib( find_lib_or_die(
+      alien => 'Neo4j::Client',
+      lib   => 'neo4j-client',
+    ));
+
 Supplying compiler flags manually (not recommended):
 
     # for ExtUtils::MakeMaker
@@ -23,6 +34,9 @@ Supplying compiler flags manually (not recommended):
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
       ...
+
+    # for FFI::Platypus
+    $ffi->lib( Neo4j::Client->dynamic_libs );
 
 # DESCRIPTION
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,25 @@ Neo4j::Client - Build and use the libneo4j-omni library
 
 # SYNOPSIS
 
-    use ExtUtils::MakeMaker;
-    use Neo4j::Client;
-    
+With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [perlxs](https://metacpan.org/pod/perlxs):
+
+    use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
+
     WriteMakefile(
-      LIBS => Neo4j::Client->libs,
-      CCFLAGS => Neo4j::Client->cflags,
+      alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
       ...
     );
+
+    # The wrapper will supply all compiler flags needed for
+    # your Perl module to use libneo4j-omni automatically.
+
+Supplying compiler flags manually (not recommended):
+
+    # for ExtUtils::MakeMaker
+    WriteMakefile(
+      CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
+      LIBS      => Neo4j::Client->libs,
+      ...
 
 # DESCRIPTION
 
@@ -28,9 +39,8 @@ autotools `autoconf-2.69`, `automake-1.16.3`, and `m4-1.4.18-patched`
 which are bundled with this distro and are known to work on this library.
 (These are required to build from ./configure for `libneo4j-omni`.)
 
-Thanks to the miracle of
-[Alien::Build](https://metacpan.org/pod/Alien::Build), the library
-should always contain OpenSSL support.
+Thanks to the miracle of [Alien::Build](https://metacpan.org/pod/Alien::Build), the library should always
+contain OpenSSL support.
 
 # SEE ALSO
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     # The wrapper will supply all compiler flags needed for
     # your Perl module to use libneo4j-omni automatically.
 
+With [Inline::C](https://metacpan.org/pod/Inline::C):
+
+    use Neo4j::Client 0.56;
+    use Inline 0.56 with => 'Neo4j::Client';
+
 With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
 
     use FFI::CheckLib 0.25;
@@ -34,6 +39,11 @@ Supplying compiler flags manually (not recommended):
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
       ...
+
+    # for Inline::C
+    use Inline 0.51 C => Config =>
+      CCFLAGSEX => Neo4j::Client->cflags,
+      LIBS      => Neo4j::Client->libs;
 
     # for FFI::Platypus
     $ffi->lib( Neo4j::Client->dynamic_libs );

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
 
     WriteMakefile(
-      alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
+      alien_requires => [ 'Neo4j::Client' ],
       ...
     );
 
@@ -64,7 +64,9 @@ which are bundled with this distro and are known to work on this library.
 (These are required to build from ./configure for `libneo4j-omni`.)
 
 Thanks to the miracle of [Alien::Build](https://metacpan.org/pod/Alien::Build), the library should always
-contain OpenSSL support.
+contain OpenSSL support. This is already taken into account by the
+methods in [Alien::Base](https://metacpan.org/pod/Alien::Base), which are inherited by this module.
+You shouldn't need to add any extra compiler flags for OpenSSL.
 
 # SEE ALSO
 

--- a/alienfile
+++ b/alienfile
@@ -94,6 +94,7 @@ share sub {
 
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;
     $bld->runtime_prop->{version} = $version;
+    $bld->runtime_prop->{legacy}->{inline_auto_include} = ['neo4j-client.h'];
   };
 };
 plugin "Gather::IsolateDynamic";

--- a/alienfile
+++ b/alienfile
@@ -80,7 +80,11 @@ share sub {
     my ($bld) = @_;
     my ($dev_cflags, $pt_cflags, $pt_libs) = scan_config_log($bld);
     my $pfx = $bld->runtime_prop->{prefix};
-    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/dynamic", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
+
+    # We're using static libs for this 'share' install because that's more
+    # reliable; see Alien::Build::Manual::AlienAuthor.
+
+    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
     $bld->runtime_prop->{libs_static} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
     $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", "-iquote${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;

--- a/alienfile
+++ b/alienfile
@@ -78,7 +78,7 @@ share sub {
    ];
   gather sub {
     my ($bld) = @_;
-    my ($dev_cflags, $pt_cflags, $pt_libs) = scan_config_log($bld);
+    my ($dev_cflags, $pt_cflags, $pt_libs, $version) = scan_config_log($bld);
     my $pfx = $bld->runtime_prop->{prefix};
 
     # We're using static libs for this 'share' install because that's more
@@ -93,6 +93,7 @@ share sub {
     $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
 
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;
+    $bld->runtime_prop->{version} = $version;
   };
 };
 plugin "Gather::IsolateDynamic";
@@ -130,6 +131,8 @@ sub scan_config_log {
   my ($cflags) = grep /^CFLAGS=/,@log;
   $cflags =~ s/^CFLAGS='//; $cflags =~ s/'\s*$//;
   $cflags =~ s/\s+-W[a-zA-Z-_=]*//g;
-  return $cflags, $pthread{PTHREAD_CFLAGS}, $pthread{PTHREAD_LIBS};
+  my ($version) = grep /^PACKAGE_VERSION=/,@log;
+  $version =~ s/.*?'(.*)'.*/$1/s if $version;
+  return $cflags, $pthread{PTHREAD_CFLAGS}, $pthread{PTHREAD_LIBS}, $version;
 }
   

--- a/alienfile
+++ b/alienfile
@@ -87,10 +87,10 @@ share sub {
     # hurt to explicitly set them here.
 
     $bld->runtime_prop->{libs_static} =
-    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, "-lneo4j-client", Alien::OpenSSL->libs);
+    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, "-lneo4j-client", Alien::OpenSSL->libs_static);
 
     $bld->runtime_prop->{cflags_static} =
-    $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
+    $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags_static);
 
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;
     $bld->runtime_prop->{version} = $version;

--- a/alienfile
+++ b/alienfile
@@ -90,7 +90,7 @@ share sub {
     $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
 
     $bld->runtime_prop->{cflags_static} =
-    $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", "-iquote${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
+    $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
 
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;
   };

--- a/alienfile
+++ b/alienfile
@@ -82,11 +82,16 @@ share sub {
     my $pfx = $bld->runtime_prop->{prefix};
 
     # We're using static libs for this 'share' install because that's more
-    # reliable; see Alien::Build::Manual::AlienAuthor.
+    # reliable; see Alien::Build::Manual::AlienAuthor. The *_static flags
+    # are probably automatically populated in Alien::Build, but it doesn't
+    # hurt to explicitly set them here.
 
+    $bld->runtime_prop->{libs_static} =
     $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
-    $bld->runtime_prop->{libs_static} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
+
+    $bld->runtime_prop->{cflags_static} =
     $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", "-iquote${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);
+
     $bld->runtime_prop->{dev_cflags} = $dev_cflags;
   };
 };

--- a/alienfile
+++ b/alienfile
@@ -87,7 +87,7 @@ share sub {
     # hurt to explicitly set them here.
 
     $bld->runtime_prop->{libs_static} =
-    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, Alien::OpenSSL->libs, "-lneo4j-client");
+    $bld->runtime_prop->{libs} = join(' ', "-L${pfx}/lib", $pt_libs, "-lneo4j-client", Alien::OpenSSL->libs);
 
     $bld->runtime_prop->{cflags_static} =
     $bld->runtime_prop->{cflags} = join(' ', "-I${pfx}/include", $pt_cflags, Alien::OpenSSL->cflags);

--- a/build/lib/src/neo4j-client.h.in
+++ b/build/lib/src/neo4j-client.h.in
@@ -3107,6 +3107,8 @@ int neo4j_u8cpwidth(int cp);
 int neo4j_u8cswidth(const char *s, size_t n);
 
 
+const char *neo4j_openssl_version(int t); /* Internal - DO NOT USE */
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus

--- a/build/lib/src/openssl.c
+++ b/build/lib/src/openssl.c
@@ -30,6 +30,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
+#include <openssl/opensslv.h>
 #pragma GCC diagnostic pop
 
 #define NEO4J_CYPHER_LIST "HIGH:!EXPORT:!aNULL@STRENGTH"
@@ -612,4 +613,13 @@ int openssl_error(neo4j_logger_t *logger, uint_fast8_t level,
             ERR_reason_error_string(code));
 
     return NEO4J_UNEXPECTED_ERROR;
+}
+
+const char *neo4j_openssl_version(int t)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 or later */
+    return OpenSSL_version(t > 0 ? t : OPENSSL_VERSION);
+#else
+    return SSLeay_version(t > 0 ? t : SSLEAY_VERSION);
+#endif
 }

--- a/lib/Neo4j/Client.md
+++ b/lib/Neo4j/Client.md
@@ -35,6 +35,7 @@ With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
 Supplying compiler flags manually (not recommended):
 
     # for ExtUtils::MakeMaker
+    use Config;
     WriteMakefile(
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
@@ -67,6 +68,14 @@ Thanks to the miracle of [Alien::Build](https://metacpan.org/pod/Alien::Build), 
 contain OpenSSL support. This is already taken into account by the
 methods in [Alien::Base](https://metacpan.org/pod/Alien::Base), which are inherited by this module.
 You shouldn't need to add any extra compiler flags for OpenSSL.
+
+# BUGS
+
+The minimum supported version of OpenSSL is currently 1.1.0.
+([GH #7](https://github.com/majensen/neoclient/issues/7))
+
+The C compiler must support the `-Wpedantic` and `-Wvla` options.
+([GH #8](https://github.com/majensen/neoclient/issues/8))
 
 # SEE ALSO
 

--- a/lib/Neo4j/Client.md
+++ b/lib/Neo4j/Client.md
@@ -16,6 +16,17 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     # The wrapper will supply all compiler flags needed for
     # your Perl module to use libneo4j-omni automatically.
 
+With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
+
+    use FFI::CheckLib 0.25;
+    use FFI::Platypus;
+
+    my $ffi = FFI::Platypus->new;
+    $ffi->lib( find_lib_or_die(
+      alien => 'Neo4j::Client',
+      lib   => 'neo4j-client',
+    ));
+
 Supplying compiler flags manually (not recommended):
 
     # for ExtUtils::MakeMaker
@@ -23,6 +34,9 @@ Supplying compiler flags manually (not recommended):
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
       ...
+
+    # for FFI::Platypus
+    $ffi->lib( Neo4j::Client->dynamic_libs );
 
 # DESCRIPTION
 

--- a/lib/Neo4j/Client.md
+++ b/lib/Neo4j/Client.md
@@ -4,14 +4,25 @@ Neo4j::Client - Build and use the libneo4j-omni library
 
 # SYNOPSIS
 
-    use ExtUtils::MakeMaker;
-    use Neo4j::Client;
-    
+With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [perlxs](https://metacpan.org/pod/perlxs):
+
+    use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
+
     WriteMakefile(
-      LIBS => Neo4j::Client->libs,
-      CCFLAGS => Neo4j::Client->cflags,
+      alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
       ...
     );
+
+    # The wrapper will supply all compiler flags needed for
+    # your Perl module to use libneo4j-omni automatically.
+
+Supplying compiler flags manually (not recommended):
+
+    # for ExtUtils::MakeMaker
+    WriteMakefile(
+      CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
+      LIBS      => Neo4j::Client->libs,
+      ...
 
 # DESCRIPTION
 

--- a/lib/Neo4j/Client.md
+++ b/lib/Neo4j/Client.md
@@ -16,6 +16,11 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     # The wrapper will supply all compiler flags needed for
     # your Perl module to use libneo4j-omni automatically.
 
+With [Inline::C](https://metacpan.org/pod/Inline::C):
+
+    use Neo4j::Client 0.56;
+    use Inline 0.56 with => 'Neo4j::Client';
+
 With [FFI::Platypus](https://metacpan.org/pod/FFI::Platypus):
 
     use FFI::CheckLib 0.25;
@@ -34,6 +39,11 @@ Supplying compiler flags manually (not recommended):
       CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
       LIBS      => Neo4j::Client->libs,
       ...
+
+    # for Inline::C
+    use Inline 0.51 C => Config =>
+      CCFLAGSEX => Neo4j::Client->cflags,
+      LIBS      => Neo4j::Client->libs;
 
     # for FFI::Platypus
     $ffi->lib( Neo4j::Client->dynamic_libs );

--- a/lib/Neo4j/Client.md
+++ b/lib/Neo4j/Client.md
@@ -9,7 +9,7 @@ With [Alien::Base::Wrapper](https://metacpan.org/pod/Alien::Base::Wrapper) for [
     use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
 
     WriteMakefile(
-      alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
+      alien_requires => [ 'Neo4j::Client' ],
       ...
     );
 
@@ -64,7 +64,9 @@ which are bundled with this distro and are known to work on this library.
 (These are required to build from ./configure for `libneo4j-omni`.)
 
 Thanks to the miracle of [Alien::Build](https://metacpan.org/pod/Alien::Build), the library should always
-contain OpenSSL support.
+contain OpenSSL support. This is already taken into account by the
+methods in [Alien::Base](https://metacpan.org/pod/Alien::Base), which are inherited by this module.
+You shouldn't need to add any extra compiler flags for OpenSSL.
 
 # SEE ALSO
 

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -23,6 +23,17 @@ With L<Alien::Base::Wrapper> for L<perlxs>:
   # The wrapper will supply all compiler flags needed for
   # your Perl module to use libneo4j-omni automatically.
 
+With L<FFI::Platypus>:
+
+  use FFI::CheckLib 0.25;
+  use FFI::Platypus;
+
+  my $ffi = FFI::Platypus->new;
+  $ffi->lib( find_lib_or_die(
+    alien => 'Neo4j::Client',
+    lib   => 'neo4j-client',
+  ));
+
 Supplying compiler flags manually (not recommended):
 
   # for ExtUtils::MakeMaker
@@ -30,6 +41,9 @@ Supplying compiler flags manually (not recommended):
     CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
     LIBS      => Neo4j::Client->libs,
     ...
+
+  # for FFI::Platypus
+  $ffi->lib( Neo4j::Client->dynamic_libs );
 
 =head1 DESCRIPTION
 

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -25,7 +25,7 @@ With L<Alien::Base::Wrapper> for L<perlxs>:
   use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
 
   WriteMakefile(
-    alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
+    alien_requires => [ 'Neo4j::Client' ],
     ...
   );
 
@@ -80,7 +80,9 @@ which are bundled with this distro and are known to work on this library.
 (These are required to build from ./configure for C<libneo4j-omni>.)
 
 Thanks to the miracle of L<Alien::Build>, the library should always
-contain OpenSSL support.
+contain OpenSSL support. This is already taken into account by the
+methods in L<Alien::Base>, which are inherited by this module.
+You shouldn't need to add any extra compiler flags for OpenSSL.
 
 
 =head1 SEE ALSO

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use base qw( Alien::Base );
 
-our $VERSION = '0.55';
+our $VERSION = '0.56';
 
 sub Inline {
   # Work around https://github.com/PerlAlien/Alien-Build/issues/430

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -11,14 +11,25 @@ Neo4j::Client - Build and use the libneo4j-omni library
 
 =head1 SYNOPSIS
 
- use ExtUtils::MakeMaker;
- use Neo4j::Client;
- 
- WriteMakefile(
-   LIBS => Neo4j::Client->libs,
-   CCFLAGS => Neo4j::Client->cflags,
-   ...
- );
+With L<Alien::Base::Wrapper> for L<perlxs>:
+
+  use Alien::Base::Wrapper 1.98 qw( WriteMakefile );
+
+  WriteMakefile(
+    alien_requires => [ 'Neo4j::Client', 'Alien::OpenSSL' ],
+    ...
+  );
+
+  # The wrapper will supply all compiler flags needed for
+  # your Perl module to use libneo4j-omni automatically.
+
+Supplying compiler flags manually (not recommended):
+
+  # for ExtUtils::MakeMaker
+  WriteMakefile(
+    CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
+    LIBS      => Neo4j::Client->libs,
+    ...
 
 =head1 DESCRIPTION
 

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -51,6 +51,7 @@ With L<FFI::Platypus>:
 Supplying compiler flags manually (not recommended):
 
   # for ExtUtils::MakeMaker
+  use Config;
   WriteMakefile(
     CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
     LIBS      => Neo4j::Client->libs,
@@ -84,6 +85,13 @@ contain OpenSSL support. This is already taken into account by the
 methods in L<Alien::Base>, which are inherited by this module.
 You shouldn't need to add any extra compiler flags for OpenSSL.
 
+=head1 BUGS
+
+The minimum supported version of OpenSSL is currently 1.1.0.
+(L<GH #7|https://github.com/majensen/neoclient/issues/7>)
+
+The C compiler must support the C<-Wpedantic> and C<-Wvla> options.
+(L<GH #8|https://github.com/majensen/neoclient/issues/8>)
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Client.pm
+++ b/lib/Neo4j/Client.pm
@@ -5,6 +5,15 @@ use base qw( Alien::Base );
 
 our $VERSION = '0.55';
 
+sub Inline {
+  # Work around https://github.com/PerlAlien/Alien-Build/issues/430
+  {
+    AUTO_INCLUDE => '#include "neo4j-client.h"',
+    CCFLAGSEX    => __PACKAGE__->cflags_static,
+    LIBS         => __PACKAGE__->libs_static,
+  }
+}
+
 =head1 NAME
 
 Neo4j::Client - Build and use the libneo4j-omni library
@@ -22,6 +31,11 @@ With L<Alien::Base::Wrapper> for L<perlxs>:
 
   # The wrapper will supply all compiler flags needed for
   # your Perl module to use libneo4j-omni automatically.
+
+With L<Inline::C>:
+
+  use Neo4j::Client 0.56;
+  use Inline 0.56 with => 'Neo4j::Client';
 
 With L<FFI::Platypus>:
 
@@ -41,6 +55,11 @@ Supplying compiler flags manually (not recommended):
     CCFLAGS   => "$Config{ccflags} " . Neo4j::Client->cflags,
     LIBS      => Neo4j::Client->libs,
     ...
+
+  # for Inline::C
+  use Inline 0.51 C => Config =>
+    CCFLAGSEX => Neo4j::Client->cflags,
+    LIBS      => Neo4j::Client->libs;
 
   # for FFI::Platypus
   $ffi->lib( Neo4j::Client->dynamic_libs );

--- a/t/001_alien.t
+++ b/t/001_alien.t
@@ -4,11 +4,14 @@ use Test::Alien;
 use Neo4j::Client;
 
 alien_ok 'Neo4j::Client';
+
 my $xs = do { local $/; <DATA> };
 xs_ok $xs, with_subtest {
   my($mod) = @_;
   ok $mod->version;
   diag $mod->version;
+
+  is $mod->neo4j_log_level_str(2), 'INFO';
 };
 
 diag(Neo4j::Client->cflags);
@@ -34,3 +37,7 @@ MODULE = TA_MODULE PACKAGE = TA_MODULE
  
 const char *version(class);
     const char *class;
+
+char *
+neo4j_log_level_str(class, U8 level)
+  C_ARGS: level

--- a/t/001_alien.t
+++ b/t/001_alien.t
@@ -14,12 +14,6 @@ xs_ok $xs, with_subtest {
   is $mod->neo4j_log_level_str(2), 'INFO';
 };
 
-ffi_ok { symbols => ['neo4j_log_level_str'] }, with_subtest {
-  my($ffi) = @_;
-  my $neo4j_log_level_str = $ffi->function( neo4j_log_level_str => ['int'] => 'string' );
-  is $neo4j_log_level_str->call(3), 'DEBUG';
-};
-
 diag(Neo4j::Client->cflags);
 diag(Neo4j::Client->libs);
   

--- a/t/001_alien.t
+++ b/t/001_alien.t
@@ -14,6 +14,12 @@ xs_ok $xs, with_subtest {
   is $mod->neo4j_log_level_str(2), 'INFO';
 };
 
+ffi_ok { symbols => ['neo4j_log_level_str'] }, with_subtest {
+  my($ffi) = @_;
+  my $neo4j_log_level_str = $ffi->function( neo4j_log_level_str => ['int'] => 'string' );
+  is $neo4j_log_level_str->call(3), 'DEBUG';
+};
+
 diag(Neo4j::Client->cflags);
 diag(Neo4j::Client->libs);
   

--- a/t/001_alien.t
+++ b/t/001_alien.t
@@ -13,7 +13,6 @@ xs_ok $xs, with_subtest {
 
 diag(Neo4j::Client->cflags);
 diag(Neo4j::Client->libs);
-diag(Neo4j::Client->libs_static);
   
 done_testing;
 

--- a/t/001_alien.t
+++ b/t/001_alien.t
@@ -4,12 +4,12 @@ use Test::Alien;
 use Neo4j::Client;
 
 alien_ok 'Neo4j::Client';
-
 my $xs = do { local $/; <DATA> };
 xs_ok $xs, with_subtest {
   my($mod) = @_;
   ok $mod->version;
-  diag $mod->version;
+  is $mod->version, Neo4j::Client->version;
+  diag 'libneo4j-omni ' . $mod->version;
 
   is $mod->neo4j_log_level_str(2), 'INFO';
 };

--- a/t/020_inline.t
+++ b/t/020_inline.t
@@ -11,6 +11,9 @@ BEGIN {
 
 use Inline with => 'Neo4j::Client';
 
+use Inline C => Config => typemaps =>
+  $::inline_dir->child('typemap')->spew_raw('uint_fast8_t T_UV')->stringify;
+
 use Inline C => 'DATA', autowrap => 1;
 
 is log_level_4_as_string(), 'TRACE', 'indirect call';
@@ -25,4 +28,4 @@ const char *log_level_4_as_string() {
   return neo4j_log_level_str(4);
 }
 
-extern const char *neo4j_log_level_str(U8 level);
+const char *neo4j_log_level_str(uint_fast8_t level);

--- a/t/020_inline.t
+++ b/t/020_inline.t
@@ -1,0 +1,28 @@
+use Test2::V0;
+
+BEGIN {
+  skip_all 'Inline::C not installed or too old'
+    unless eval { require Inline::C; Inline->VERSION('0.56') };
+
+  require Path::Tiny;
+  our $inline_dir = Path::Tiny->tempdir('neo4j-client-inline-XXXXXX');
+  $ENV{PERL_INLINE_DIRECTORY} = $inline_dir->absolute->stringify;
+}
+
+use Inline with => 'Neo4j::Client';
+
+use Inline C => 'DATA', autowrap => 1;
+
+is log_level_4_as_string(), 'TRACE', 'indirect call';
+is neo4j_log_level_str(2), 'INFO', 'direct call';
+
+done_testing;
+
+__DATA__
+__C__
+
+const char *log_level_4_as_string() {
+  return neo4j_log_level_str(4);
+}
+
+extern const char *neo4j_log_level_str(U8 level);

--- a/t/021_ffi.t
+++ b/t/021_ffi.t
@@ -1,0 +1,18 @@
+use Test2::V0;
+use Test::Alien;
+use Neo4j::Client;
+
+BEGIN {
+  skip_all 'FFI::Platypus not installed'
+    unless eval { require FFI::Platypus; 1 };
+}
+
+alien_ok 'Neo4j::Client';
+ffi_ok { symbols => ['neo4j_log_level_str'] }, with_subtest {
+  my($ffi) = @_;
+
+  my $neo4j_log_level_str = $ffi->function( neo4j_log_level_str => ['int'] => 'string' );
+  is $neo4j_log_level_str->call(3), 'DEBUG';
+};
+  
+done_testing;

--- a/t/030_sslversion.t
+++ b/t/030_sslversion.t
@@ -1,0 +1,32 @@
+use Test2::V0;
+use Test::Alien;
+use Neo4j::Client;
+
+alien_ok 'Neo4j::Client';
+
+my $xs = do { local $/; <DATA> };
+xs_ok $xs, with_subtest {
+  my($mod) = @_;
+
+  ok my $openssl_version = $mod->neo4j_openssl_version(0);
+  diag($mod->neo4j_openssl_version($_)) for 0, 4, 5;
+};
+
+done_testing;
+
+# This test relies on a patch made by nc-update to lib/src/openssl.c.
+# The point is to verify that both Omni and OpenSSL are linked correctly.
+# As a bonus, we get diagnostic output of the OpenSSL version number.
+
+__DATA__
+
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+#include <neo4j-client.h>
+
+MODULE = TA_MODULE PACKAGE = TA_MODULE
+
+const char *
+neo4j_openssl_version(class, int t)
+  C_ARGS: t

--- a/t/030_sslversion.t
+++ b/t/030_sslversion.t
@@ -3,7 +3,6 @@ use Test::Alien;
 use Neo4j::Client;
 
 alien_ok 'Neo4j::Client';
-
 my $xs = do { local $/; <DATA> };
 xs_ok $xs, with_subtest {
   my($mod) = @_;

--- a/t/030_sslversion.t
+++ b/t/030_sslversion.t
@@ -2,6 +2,11 @@ use Test2::V0;
 use Test::Alien;
 use Neo4j::Client;
 
+BEGIN {
+  require Alien::OpenSSL;
+  diag('Alien::OpenSSL package version ' . Alien::OpenSSL->version);
+}
+
 alien_ok 'Neo4j::Client';
 my $xs = do { local $/; <DATA> };
 xs_ok $xs, with_subtest {


### PR DESCRIPTION
Changes in this PR:
- Use the path to the static libraries for `libs` instead of the dynamic ones, see ["A note about dynamic vs. static libraries" in Alien::Build::Manual::AlienAuthor](https://metacpan.org/release/PLICEASE/Alien-Build-2.84/view/lib/Alien/Build/Manual/AlienAuthor.pod#A-note-about-dynamic-vs.-static-libraries)
- Clean up the Alien metadata some more
- Rewrite synopsis in docs to show a better way to use this module through Alien::Base::Wrapper, as mentioned previously in [perlbolt#59 (comment)](https://github.com/majensen/perlbolt/pull/59#issuecomment-2456720693)
- Add support for `use Inline with => 'Neo4j::Client';`
- Add a few more tests, especially for using this module through Inline::C and Platypus::FFI
- Expand the [build instructions](https://github.com/majensen/neoclient/blob/eadc6ad7ae37d2d3e5c948f9f955466a7549afba/BUILD.md) and add some entries to `.gitignore` / `MANIFEST.SKIP`